### PR TITLE
Collect and build all examples via the docker-build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ export GOPATH \
 
 
 include examples/examples.mk
+include mk/docker.mk
 
-.PHONY: all
+.PHONY: all check verify
 all: check verify docker-build
 
 .PHONY: check

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -29,3 +29,6 @@ docker-%-push: docker-login docker-%-build
 	docker tag ${ORG}/$*:${COMMIT} ${ORG}/$*:${TAG}
 	docker tag ${ORG}/$*:${COMMIT} ${ORG}/$*:${BUILD_TAG}
 	docker push ${ORG}/$*
+
+.PHONY: docker-build
+docker-build: $(addsuffix -build,$(addprefix k8s-,$(EXAMPLE_NAMES)))

--- a/mk/targets.mk
+++ b/mk/targets.mk
@@ -4,6 +4,7 @@ include $(TOP)/mk/docker-targets.mk
 
 define BUILD
 .PHONY: $(PREFIX)-$(NAME)-build
+EXAMPLE_NAMES+=${NAME}
 $(PREFIX)-$(NAME)-build: $(addsuffix -build,$(addprefix ${CONTAINER_BUILD_PREFIX}-$(NAME)-,$(CONTAINERS)))
 endef
 $(eval $(BUILD))


### PR DESCRIPTION
It also fixes the missing `docker-build` target.

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>