### PR TITLE
examples/bridge-domain minor fixes

### DIFF
--- a/examples/bridge-domain/k8s/simple-client-ipv6.yaml
+++ b/examples/bridge-domain/k8s/simple-client-ipv6.yaml
@@ -17,6 +17,6 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ['tail', '-f', '/dev/null']
 metadata:
-  name: simple-client
+  name: simple-client-ipv6
   annotations:
     ns.networkservicemesh.io: bridge-domain-ipv6?app=bridge-ipv6

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,12 @@ module github.com/networkservicemesh/examples
 go 1.12
 
 require (
-	github.com/Nordix/simple-ipam v0.0.0-20190927091958-9f5768691be0
+	github.com/Nordix/simple-ipam v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/golang/protobuf v1.3.2
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/ligato/vpp-agent v2.1.1+incompatible
-	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 // indirect
 	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
 	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
 	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v0.0.0-20190321161819-752af9db25a0/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
-github.com/Nordix/simple-ipam v0.0.0-20190927091958-9f5768691be0 h1:kcIvEg1yCpgWaGEzf/OXkoCzMKk7F+drD9qRzM9/ED4=
-github.com/Nordix/simple-ipam v0.0.0-20190927091958-9f5768691be0/go.mod h1:7d9TR/lF/zpNDHYhT43qhewce8vNdzVG5kCk7K9dPac=
+github.com/Nordix/simple-ipam v1.0.0 h1:oMyASgx2EEH0ccjAEBgCgCviu7z4uB+Od7UUCBxqcFE=
+github.com/Nordix/simple-ipam v1.0.0/go.mod h1:7d9TR/lF/zpNDHYhT43qhewce8vNdzVG5kCk7K9dPac=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -143,8 +143,6 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
-github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
-github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721/go.mod h1:Ickgr2WtCLZ2MDGd4Gr0geeCH5HybhRJbonOgQpvSxc=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=


### PR DESCRIPTION
This is a very small fix.

The same name was used in the ipv4 and ipv6 examples making is impossible to run them in the same cluster at the same time (most annoying);

* Use v1.0.0 of https://github.com/Nordix/simple-ipam
* Avoid name conflict ipv4/ipv6 example

Also update a version (and get rid of one dependency).