### PR TITLE
Update the proxy example to have three colored nginx instances

### DIFF
--- a/examples/proxy/Makefile
+++ b/examples/proxy/Makefile
@@ -2,7 +2,7 @@
 NAME = proxy
 DESCRIPTION = "HTTP reverse proxy, which maps the HTTP requests to NSM Client requests"
 CONTAINERS = nginx sidecar-nse proxy-nsc
-PODS = proxy-nsc nginx-nse
+PODS = proxy-nsc nginx-red nginx-green nginx-blue
 NETWORK_SERVICES = web-service
 CHECK = export ITERATIONS=10 && export BATCHES=1 && scripts/verify_proxy_nsc.sh
 

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -6,14 +6,41 @@ outside facing service. Upon HTTP connection request, the proxy will create
 a new NS connection. The connection is configured by env variables as an usual
 NS Client. The proxy will scan the HTTP request for headers of format:
     `NSM-<label>:<value>`
-These would be transformed to NS Client request labels.
+These would be transformed to NS Client request labels. The proxy itself always labels its
+requests with `app=proxy`.
+
+In this example we deploy three NGiNX Endpoints all implementing the `web-service`,
+but all are labelled with differet `color=<color>`, where `color` is `red`, `green`
+or `blue`.
+
+The Network Service description is written in a way that the connection will be wired
+depending on the `color` label in the connection request. In case there is no such label
+or it referes to a different color, NSM will do a round robin on the selection of the endpoints.
+Meaning that each request will result in establishing a conenction to a different NGiNX and
+effectively showing a web page with different color.
 
 ```
-                       +------------+                      +-------------+
-  GET / HTTP/1.1       |            |                      |             |
-  NSM-App: Firewall    |            |     app=firewall     |             |
-+----------------------> Proxy NSC  +----------------------> NS Endpoint |
-                       |            |                      |             |
-                       |            |                      |             |
-                       +------------+                      +-------------+
+                                                            +-------------+
+                                                            |             |
+                                                            | nginx-red   |
+                                                       +---->             |
+                                                       |    | app=nginx   |
+                                                       |    | color=red   |
+                                                       |    +-------------+
+                                                       |
+                       +------------+                  |    +-------------+
+  GET / HTTP/1.1       |            |     app=proxy    |    |             |
+  NSM+App: Red         |            |     color=red    |    | nginx-green |
++----------------------> Proxy NSC  +----------------------->             |
+                       |            |                  |    | app=nginx   |
+                       |            |                  |    | color=green |
+                       +------------+                  |    +-------------+
+                                                       |
+                                                       |    +-------------+
+                                                       |    |             |
+                                                       |    | nginx-blue  |
+                                                       +---->             |
+                                                            | app=nginx   |
+                                                            | color=blue  |
+                                                            +-------------+
 ```

--- a/examples/proxy/k8s/nginx-blue.yaml
+++ b/examples/proxy/k8s/nginx-blue.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "nginx-nse"
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "nginx-nse"
+        networkservicemesh.io/impl: "web-service"
+    spec:
+      containers:
+        - name: sidecar-nse
+          image: networkservicemesh/proxy-sidecar-nse:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ADVERTISE_NSE_NAME
+              value: "web-service"
+            - name: ADVERTISE_NSE_LABELS
+              value: "app=nginx,color=blue"
+            - name: TRACER_ENABLED
+              value: "true"
+            - name: IP_ADDRESS
+              value: "10.60.3.0/24"
+          resources:
+            limits:
+              networkservicemesh.io/socket: 1
+        - name: nginx
+          image: networkservicemesh/proxy-nginx
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /usr/share/nginx/html/index.html
+              subPath: index.html
+              name: index-html
+      volumes:
+        - name: index-html
+          configMap:
+            name: index-html-blue
+metadata:
+  name: nginx-blue
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: index-html-blue
+data:
+  index.html: |
+    <html>
+        <head><title>Network Service Mesh</title></head>
+    <body bgcolor="Blue">
+        <center>
+            <br><br><br><br><br><br><br><br><br><br>
+            <h1 style="color:White;">Welcome to NSM!</h1>
+        </center>
+    </body>
+    </html>

--- a/examples/proxy/k8s/nginx-green.yaml
+++ b/examples/proxy/k8s/nginx-green.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "nginx-nse"
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "nginx-nse"
+        networkservicemesh.io/impl: "web-service"
+    spec:
+      containers:
+        - name: sidecar-nse
+          image: networkservicemesh/proxy-sidecar-nse:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ADVERTISE_NSE_NAME
+              value: "web-service"
+            - name: ADVERTISE_NSE_LABELS
+              value: "app=nginx,color=green"
+            - name: TRACER_ENABLED
+              value: "true"
+            - name: IP_ADDRESS
+              value: "10.60.2.0/24"
+          resources:
+            limits:
+              networkservicemesh.io/socket: 1
+        - name: nginx
+          image: networkservicemesh/proxy-nginx
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /usr/share/nginx/html/index.html
+              subPath: index.html
+              name: index-html
+      volumes:
+        - name: index-html
+          configMap:
+            name: index-html-green
+metadata:
+  name: nginx-green
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: index-html-green
+data:
+  index.html: |
+    <html>
+        <head><title>Network Service Mesh</title></head>
+    <body bgcolor="Green">
+        <center>
+            <br><br><br><br><br><br><br><br><br><br>
+            <h1 style="color:White;">Welcome to NSM!</h1>
+        </center>
+    </body>
+    </html>

--- a/examples/proxy/k8s/nginx-red.yaml
+++ b/examples/proxy/k8s/nginx-red.yaml
@@ -20,7 +20,7 @@ spec:
             - name: ADVERTISE_NSE_NAME
               value: "web-service"
             - name: ADVERTISE_NSE_LABELS
-              value: "app=nginx-nse"
+              value: "app=nginx,color=red"
             - name: TRACER_ENABLED
               value: "true"
             - name: IP_ADDRESS
@@ -31,6 +31,30 @@ spec:
         - name: nginx
           image: networkservicemesh/proxy-nginx
           imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /usr/share/nginx/html/index.html
+              subPath: index.html
+              name: index-html
+      volumes:
+        - name: index-html
+          configMap:
+            name: index-html-red
 metadata:
-  name: nginx-nse
+  name: nginx-red
   namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: index-html-red
+data:
+  index.html: |
+    <html>
+        <head><title>Network Service Mesh</title></head>
+    <body bgcolor="Red">
+        <center>
+            <br><br><br><br><br><br><br><br><br><br>
+            <h1 style="color:White;">Welcome to NSM!</h1>
+        </center>
+    </body>
+    </html>

--- a/examples/proxy/k8s/proxy-nsc.yaml
+++ b/examples/proxy/k8s/proxy-nsc.yaml
@@ -23,7 +23,9 @@ spec:
             - name: OUTGOING_NSC_NAME
               value: "web-service"
             - name: PROXY_HOST
-              value: ":8080"
+              value: "0.0.0.0:8080"
+          ports:
+            - containerPort: 8080
           resources:
             limits:
               networkservicemesh.io/socket: 1

--- a/examples/proxy/k8s/web-service.yaml
+++ b/examples/proxy/k8s/web-service.yaml
@@ -7,7 +7,36 @@ spec:
   payload: IP
   matches:
     - match:
+      sourceSelector:
+        app: proxy
+        color: red
       route:
         - destination:
           destinationSelector:
-            app: nginx-nse
+            app: nginx
+            color: red
+    - match:
+      sourceSelector:
+        app: proxy
+        color: green
+      route:
+        - destination:
+          destinationSelector:
+            app: nginx
+            color: green
+    - match:
+      sourceSelector:
+        app: proxy
+        color: blue
+      route:
+        - destination:
+          destinationSelector:
+            app: nginx
+            color: blue
+    - match:
+      sourceSelector:
+        app: proxy
+      route:
+        - destination:
+          destinationSelector:
+            app: nginx

--- a/examples/proxy/nginx/Dockerfile
+++ b/examples/proxy/nginx/Dockerfile
@@ -1,4 +1,2 @@
 FROM nginx
 COPY examples/proxy/nginx/conf/default.conf /etc/nginx/conf.d/
-COPY examples/proxy/nginx/html /usr/share/nginx/html
-RUN dd if=/dev/urandom of=/usr/share/nginx/html/huge.bin bs=1M count=64

--- a/examples/proxy/nginx/html/index.html
+++ b/examples/proxy/nginx/html/index.html
@@ -1,6 +1,0 @@
-<html>
-    <head><title>Network Service Mesh</title></head>
-<body>
-    <h1>Welcome to NSM!</h1>
-</body>
-</html>

--- a/examples/proxy/proxy-nsc/Dockerfile
+++ b/examples/proxy/proxy-nsc/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as build
-RUN apk --no-cache add git
+RUN apk --no-cache add git curl
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
 

--- a/examples/proxy/proxy-nsc/cmd/nsc.go
+++ b/examples/proxy/proxy-nsc/cmd/nsc.go
@@ -56,6 +56,9 @@ func nsmDirector(req *http.Request) {
 	// Convert the request headers to labels
 	state.client.OutgoingNscLabels = make(map[string]string)
 
+	// Ensure we always label ourselves as `app=proxy`
+	state.client.OutgoingNscLabels["app"] = "proxy"
+
 	for name, headers := range req.Header {
 		name = strings.ToLower(name)
 		if strings.HasPrefix(name, proxyHeaderPrefix) {


### PR DESCRIPTION
the proxy is now demonstrating how NSM uses labels and how to dynamically
take advantage of these. The Network Service Descriptor will also allow
for demoing the round robin between the endpoints, when there is no `color`
label, or the color does not exist in the set of labelled endpoints.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>