### PR TITLE
Added serviceAccount in bridge-domain manifests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,12 +176,12 @@ workflows:
           description: "4G Network Topology example"
           requires:
             - sanity-check
-      # - test:
-      #     name: "Test Bridge domain"
-      #     example: "bridge-domain"
-      #     description: "A simple VPP bridge domain example"
-      #     requires:
-      #       - sanity-check
+      - test:
+          name: "Test Bridge domain"
+          example: "bridge-domain"
+          description: "A simple VPP bridge domain example"
+          requires:
+            - sanity-check
       - test:
           name: "Test Envoy"
           example: "envoy_interceptor"

--- a/examples/bridge-domain/k8s/bridge-ipv6.yaml
+++ b/examples/bridge-domain/k8s/bridge-ipv6.yaml
@@ -13,6 +13,7 @@ spec:
         networkservicemesh.io/app: "bridge-domain-ipv6"
         networkservicemesh.io/impl: "bridge-ipv6"
     spec:
+      serviceAccount: nse-acc
       containers:
         - name: bridge-domain
           image: networkservicemesh/bridge-domain-bridge:latest

--- a/examples/bridge-domain/k8s/bridge.yaml
+++ b/examples/bridge-domain/k8s/bridge.yaml
@@ -13,6 +13,7 @@ spec:
         networkservicemesh.io/app: "bridge-domain"
         networkservicemesh.io/impl: "bridge"
     spec:
+      serviceAccount: nse-acc
       containers:
         - name: bridge-domain
           image: networkservicemesh/bridge-domain-bridge:latest

--- a/examples/bridge-domain/k8s/simple-client-ipv6.yaml
+++ b/examples/bridge-domain/k8s/simple-client-ipv6.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         networkservicemesh.io/app: "simple-client-ipv6"
     spec:
+      serviceAccount: nsc-acc
       containers:
         - name: alpine-img
           image: alpine:latest

--- a/examples/bridge-domain/k8s/simple-client.yaml
+++ b/examples/bridge-domain/k8s/simple-client.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         networkservicemesh.io/app: "simple-client"
     spec:
+      serviceAccount: nsc-acc
       containers:
         - name: alpine-img
           image: alpine:latest


### PR DESCRIPTION
This is required for insecure=false operation.

This PR only adds "serviceAccount: nsc-acc" (or "serviceAccount: nse-acc") in manifests. Without this clients get stuck in "Init" unless "insecure=true" is set.