### PR TITLE
Apply metrics observability

### DIFF
--- a/examples/4g-network/sidecar-nse/Dockerfile
+++ b/examples/4g-network/sidecar-nse/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root/networkservicemesh/
 RUN go mod download
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/sidecar-nse ./examples/proxy/sidecar-nse/cmd/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/sidecar-nse ./examples/4g-network/sidecar-nse/cmd/main.go
 FROM alpine as runtime
 COPY --from=build /go/bin/sidecar-nse /bin/sidecar-nse
 ENTRYPOINT ["/bin/sidecar-nse"]

--- a/examples/4g-network/sidecar-nse/cmd/main.go
+++ b/examples/4g-network/sidecar-nse/cmd/main.go
@@ -29,10 +29,12 @@ func main() {
 	c := tools.NewOSSignalChannel()
 
 	configuration := common.FromEnv()
+	podName := endpoint.CreatePodNameMutator()
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),
 		endpoint.NewConnectionEndpoint(configuration),
 		endpoint.NewIpamEndpoint(configuration),
+		endpoint.NewCustomFuncEndpoint("podName", podName),
 	)
 
 	nsmEndpoint, err := endpoint.NewNSMEndpoint(context.Background(), configuration, composite)


### PR DESCRIPTION
This adds pod name mutator to the 4g-network endpoint, so that metrics
can be exposed to Prometheus. Also fixes a the 4g-network path in the
Dockerfile

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>