### PR TITLE
Apply prometheus integration requirements to all examples

### DIFF
--- a/examples/bridge-domain/bridge/cmd/main.go
+++ b/examples/bridge-domain/bridge/cmd/main.go
@@ -33,9 +33,11 @@ func main() {
 		MechanismType: memif.MECHANISM,
 	}).FromEnv()
 
+	podName := endpoint.CreatePodNameMutator()
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),
 		endpoint.NewConnectionEndpoint(configuration),
+		endpoint.NewCustomFuncEndpoint("podName", podName),
 		NewIpamEndpoint(configuration),
 		newVppAgentBridgeComposite(configuration),
 	)

--- a/examples/envoy_interceptor/envoy-nse/cmd/main.go
+++ b/examples/envoy_interceptor/envoy-nse/cmd/main.go
@@ -28,11 +28,13 @@ func main() {
 	// Capture signals to cleanup before exiting
 	c := tools.NewOSSignalChannel()
 	configuration := common.FromEnv()
+	podName := endpoint.CreatePodNameMutator()
 	composite := endpoint.NewCompositeEndpoint(
 		NewIptablesEndpoint(),
 		endpoint.NewMonitorEndpoint(configuration),
 		endpoint.NewConnectionEndpoint(configuration),
 		endpoint.NewIpamEndpoint(configuration),
+		endpoint.NewCustomFuncEndpoint("podName", podName),
 	)
 
 	nsmEndpoint, err := endpoint.NewNSMEndpoint(context.TODO(), configuration, composite)

--- a/examples/proxy/sidecar-nse/cmd/main.go
+++ b/examples/proxy/sidecar-nse/cmd/main.go
@@ -29,10 +29,12 @@ func main() {
 	c := tools.NewOSSignalChannel()
 
 	configuration := common.FromEnv()
+	podName := endpoint.CreatePodNameMutator()
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),
 		endpoint.NewConnectionEndpoint(configuration),
 		endpoint.NewIpamEndpoint(configuration),
+		endpoint.NewCustomFuncEndpoint("podName", podName),
 	)
 
 	nsmEndpoint, err := endpoint.NewNSMEndpoint(context.Background(), configuration, composite)

--- a/examples/secure-intranet/vppagent-endpoint/cmd/main.go
+++ b/examples/secure-intranet/vppagent-endpoint/cmd/main.go
@@ -40,10 +40,12 @@ func main() {
 		MechanismType: memif.MECHANISM,
 	}).FromEnv()
 
+	podName := endpoint.CreatePodNameMutator()
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),
 		endpoint.NewConnectionEndpoint(configuration),
 		endpoint.NewClientEndpoint(configuration),
+		endpoint.NewCustomFuncEndpoint("podName", podName),
 		vppagent.NewClientMemifConnect(configuration),
 		vppagent.NewMemifConnect(configuration),
 		vppagent.NewXConnect(configuration),

--- a/examples/topology/sidecar-nse/cmd/main.go
+++ b/examples/topology/sidecar-nse/cmd/main.go
@@ -28,11 +28,13 @@ func main() {
 	c := tools.NewOSSignalChannel()
 
 	configuration := common.FromEnv()
+	podName := endpoint.CreatePodNameMutator()
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),
 		endpoint.NewConnectionEndpoint(configuration),
 		NewIfnameEndpoint(configuration),
 		endpoint.NewIpamEndpoint(configuration),
+		endpoint.NewCustomFuncEndpoint("podName", podName),
 	)
 
 	nsmEndpoint, err := endpoint.NewNSMEndpoint(context.Background(), configuration, composite)


### PR DESCRIPTION
This change wraps all the endpoints in the examples with pod name mutator,
following the NSM documentation for metrics, in order to expose pod names
to the cross-connect monitor, who is responsible for tracking metrics in
Prometheus

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>