### PR TITLE
Improved test in examples/load-balancer

### DIFF
--- a/examples/load-balancer/image/Dockerfile
+++ b/examples/load-balancer/image/Dockerfile
@@ -14,6 +14,7 @@ ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/bridge-domain ./examples/load-balancer/image/cmd/
 
 FROM ${VPP_AGENT} as runtime
+RUN apt update && apt install -y netcat-openbsd && rm -rf /var/lib/apt/lists/*
 COPY --from=build /go/bin/bridge-domain /bin/bridge-domain
 COPY ./examples/load-balancer/image/bin/ /bin/
 COPY ./examples/load-balancer/image/etc/ /etc/

--- a/examples/load-balancer/scripts/check_load_balancer.sh
+++ b/examples/load-balancer/scripts/check_load_balancer.sh
@@ -50,6 +50,10 @@ cmd_test() {
 
 	cmd_check_load_balancer
 	cmd_check_as
+	cmd_status
+	cmd_check_gre
+	cmd_test_ping
+	cmd_test_loadbalancing
 }
 
 cmd_check_load_balancer() {
@@ -79,6 +83,97 @@ cmd_check_as() {
 	log "Application server PODs [$aspods]"
 	kubectl wait -n default --timeout=30s --for condition=Ready $aspods || \
 		die "AS-pods not ready"
+}
+
+##  status
+##    Print route status and ping.
+cmd_status() {
+	local cmd
+	local pod=$(kubectl get pods -l networkservicemesh.io/app=load-balancer -o name)
+	log "==== Status in pod [$pod]"
+	for cmd in "vppctl show int" \
+		"vppctl show lb vips verbose" \
+		"vppctl ping 10.60.1.4 repeat 1" \
+		"ping -c1 -W1 10.70.0.1" \
+		"ping -c1 -W1 10.60.1.4" \
+		"ip addr show" \
+		"ip ro" \
+		"ip ro get 10.2.2.2" \
+		; do
+		log "Cmd [$cmd]"
+		kubectl exec $pod -- $cmd
+	done
+
+	pod=$(kubectl get pods -l networkservicemesh.io/app=application-server -o name | head -1)
+	log "==== Status in pod [$pod]"
+	for cmd in \
+		"ip link show" \
+		"ip addr show" \
+		"ip ro" \
+		"ip rule" \
+		"ip ro show table 222" \
+		; do
+		log "Cmd [$cmd]"
+		kubectl exec -c alpine-img $pod -- $cmd
+	done
+
+	return 0
+}
+
+cmd_check_gre() {
+	log "==== Check GRE access"
+	local pod=$(kubectl get pods -l networkservicemesh.io/app=load-balancer -o name)
+	local cmd
+	for cmd in \
+		"ip tunnel add foo4 mode gre remote 10.60.1.4" \
+		"ip addr add 10.70.0.5/32 dev foo4" \
+		"ip link set up dev foo4" \
+		"ip ro add 10.2.2.3/32 dev foo4" \
+		"ping -c1 -W1 10.2.2.3" \
+		; do
+		log "Cmd [$cmd]"
+		kubectl exec $pod -- $cmd
+	done
+
+}
+
+##  test_ping
+##    Ping the VIP address
+cmd_test_ping() {
+	log "Ping the VIP address"
+	local now begin=$(date +%s)
+	local lbpod=$(kubectl get pods -l networkservicemesh.io/app=load-balancer -o name)
+	while ! kubectl exec $lbpod -- ping -c1 -W1 10.2.2.2; do
+		now=$(date +%s)
+		test $((now-begin)) -gt 60 && die "Ping failed"
+		sleep 1
+	done
+	return 0
+}
+
+##  test_loadbalancing
+cmd_test_loadbalancing() {
+	log "Test load-balancing"
+	local lbpod=$(kubectl get pods -l networkservicemesh.io/app=load-balancer -o name)
+	log "load-balancer pod [$lbpod]"
+	cmd='for i in $(seq 1 30); do nc -w 2 10.2.2.2 5001 < /dev/null; done'
+	log "Execute command [$cmd]"
+	kubectl exec $lbpod -- sh -c "$cmd" | tee /tmp/lb-data.txt
+	cmd_freq /tmp/lb-data.txt | tee /tmp/lb-freq.txt
+	local i=$(cat /tmp/lb-freq.txt | wc -l)
+	test $i -lt 2 && die "No loadbalancing"
+	# Note to nitpickers;
+	# Yes, this test has probability to fail, I get it to 1/3^29 if the lb-targets are random
+}
+
+cmd_freq() {
+	test -n "$1" || die "No file"
+	test -r "$1" || die "Not readable [$1]"
+	local n i
+	for n in $(sort < $1 | uniq); do
+		i=$(grep $n $1 | wc -l)
+		echo "$n:$i"
+	done
 }
 
 # Get the command. Use "test" as default.


### PR DESCRIPTION
Tests load-balancing from the NSE-pod.

Fixes #82

The vip address is accessed 30 times and the lb-data is collected and the frequence of targets computed. Example of test printout;
```
application-server-584d4c94b6-2nh5n:11
application-server-584d4c94b6-jwl72:9
application-server-584d4c94b6-s7mhz:10
```
If only one target is found there is no load-balancing and the test fails.
