### PR TITLE
Bump golangci-lint to 1.23.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           name: Install golangci-lint
           command: |
-            export GOLANGCI_LINT_VER=1.23.1
+            export GOLANGCI_LINT_VER=1.23.8
             wget https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VER}/golangci-lint-${GOLANGCI_LINT_VER}-linux-amd64.tar.gz
             tar -xvf golangci-lint-${GOLANGCI_LINT_VER}-linux-amd64.tar.gz
             sudo mv golangci-lint-${GOLANGCI_LINT_VER}-linux-amd64/golangci-lint /usr/local/bin/


### PR DESCRIPTION
This fixes the failing CI due to outdated lint modules

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>