### PR TITLE
Fix kind version to 0.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - run:
           name: Install kind
           command: |
-            GO111MODULE="on" go get -u sigs.k8s.io/kind@master
+            GO111MODULE="on" go get -u sigs.k8s.io/kind@v0.8.1
             kind version
       - checkout
       - run:


### PR DESCRIPTION
The API in master is moving to v1alpha4 which might create issues.
Fix the version to avoid these.


Signed-off-by: Nikolay Nikolaev <nikolay.nikolaev@konghq.com>