### PR TITLE
Add python server on gateway to fix secure-intranet check

### DIFF
--- a/examples/secure-intranet/k8s/gateway.yaml
+++ b/examples/secure-intranet/k8s/gateway.yaml
@@ -32,5 +32,9 @@ spec:
         - name: nginx
           image: networkservicemesh/nginx
           imagePullPolicy: IfNotPresent
+        - name: python
+          image: python:slim
+          command: ["python", "-m", "http.server", "8080"]
+          imagePullPolicy: IfNotPresent
 metadata:
   name: gateway


### PR DESCRIPTION
The secure-intranet check contains a false positive. There is no service running on port 8080 in the gateway, so the wget on port 8080 always fails, regardless of the ACL filter working. 

This PR adds a python server running on 8080.

Fixes #92 