### PR TITLE
Fix consolemd check

### DIFF
--- a/mk/targets.mk
+++ b/mk/targets.mk
@@ -94,7 +94,7 @@ $(NAME)-list:
 
 .PHONY: $(NAME)-describe
 $(NAME)-describe:
-	@if [ -x $(which consolemd) ]; then \
+	@if command -v consolemd >/dev/null; then \
 		consolemd examples/$(NAME)/README.md; \
 	else \
 		more examples/$(NAME)/README.md; \


### PR DESCRIPTION
Currently it just fails when `consolemd` isn't installed.

```
$ make bridge-domain-describe
/bin/bash: consolemd: command not found
make: *** [/x/examples/mk/targets.mk:104: bridge-domain-describe] Error 12
```